### PR TITLE
 support RelayState parameter for okta

### DIFF
--- a/awsprocesscreds/cli.py
+++ b/awsprocesscreds/cli.py
@@ -53,9 +53,9 @@ def saml(argv=None, prompter=getpass.getpass, client_creator=None,
     if args.verbose:
         logger = logging.getLogger('awsprocesscreds')
         logger.setLevel(logging.INFO)
-        handler = PrettyPrinterLogHandler(sys.stdout)
+        handler = PrettyPrinterLogHandler(sys.stderr)
         handler.setLevel(logging.INFO)
-        formatter = logging.Formatter('%(message)s')
+        formatter = logging.Formatter('[%(levelname)s][%(pathname)s:%(lineno)d] %(message)s')
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -379,8 +379,8 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
             prompt = ("Please choose from the following authentication"
                       "choices:\r\n") + prompt
             prompt += ("Enter the number corresponding to your choice "
-                       "or press RETURN\r\n")
-            response = self.get_response("to cancel authentication: ")
+                       "or press RETURN to cancel authentication: ")
+            response = self.get_response(prompt)
             choice = 0
             try:
                 choice = int(response)

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -7,6 +7,7 @@ from hashlib import sha1
 from copy import deepcopy
 
 import six
+from six.moves import input
 import requests
 import botocore
 from botocore.client import Config
@@ -17,7 +18,6 @@ from botocore.credentials import CachedCredentialFetcher
 import botocore.session
 
 from .compat import escape
-from six.moves import input
 
 
 class SAMLError(Exception):

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -281,12 +281,12 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
                 return self.get_assertion_from_response(endpoint, totp_parsed)
             elif totp_response.status_code >= 400:
                 error = totp_parsed["errorCauses"][0]["errorSummary"]
-                _password_prompter("%s\r\nPress RETURN to continue\r\n"
-                                   % error)
+                self._password_prompter("%s\r\nPress RETURN to continue\r\n"
+                                        % error)
 
     def process_mfa_push(self, endpoint, url, statetoken):
-        _password_prompter(("Waiting for result of push notification ..."
-                            "press RETURN to continue"))
+        self._password_prompter(("Waiting for result of push notification ..."
+                                 "press RETURN to continue"))
         while True:
             totp_response = self._requests_session.post(
                 url,
@@ -315,8 +315,8 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
                 return self.get_assertion_from_response(endpoint, totp_parsed)
             elif totp_response.status_code >= 400:
                 error = totp_parsed["errorCauses"][0]["errorSummary"]
-                _password_prompter("%s\r\nPress RETURN to continue\r\n"
-                                   % error)
+                self._password_prompter("%s\r\nPress RETURN to continue\r\n"
+                                        % error)
 
     def verify_sms_factor(self, url, statetoken, passcode):
         body = {'stateToken': statetoken}
@@ -331,8 +331,8 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
 
     def process_mfa_sms(self, endpoint, url, statetoken):
         # Need to trigger the initial code to be sent ...
-        _password_prompter(("Requesting code to be sent to your phone ..."
-                            " press RETURN to continue"))
+        self._password_prompter(("Requesting code to be sent to your phone ..."
+                                 " press RETURN to continue"))
         self.verify_sms_factor(url, statetoken, "")
         while True:
             response = self.get_response(self._MSG_SMS_CODE)
@@ -348,8 +348,9 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
                                                             sms_parsed)
                 elif sms_response.status_code >= 400:
                     error = sms_parsed["errorCauses"][0]["errorSummary"]
-                    _password_prompter("%s\r\nPress RETURN to continue\r\n"
-                                       % error)
+                    self._password_prompter(("%s\r\n"
+                                             "Press RETURN to continue\r\n")
+                                            % error)
 
     def display_mfa_choices(self, parsed):
         index = 1

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -1,5 +1,4 @@
-from sys import version_info
-
+from __future__ import print_function
 import base64
 import getpass
 import logging
@@ -18,6 +17,7 @@ from botocore.credentials import CachedCredentialFetcher
 import botocore.session
 
 from .compat import escape
+from six.moves import input
 
 
 class SAMLError(Exception):
@@ -248,11 +248,7 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
     )
 
     def get_response(self, prompt):
-        py3 = version_info[0] > 2
-        if py3:
-            response = input(prompt)
-        else:
-            response = raw_input(prompt)
+        response = input(prompt)
         if response == "":
             raise SAMLError(self._ERROR_AUTH_CANCELLED)
         return response

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -280,10 +280,13 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
             if totp_response.status_code == 200:
                 return self.get_assertion_from_response(endpoint, totp_parsed)
             elif totp_response.status_code >= 400:
-                print(totp_parsed["errorCauses"][0]["errorSummary"])
+                error = totp_parsed["errorCauses"][0]["errorSummary"]
+                getpass.getpass("%s\r\nPress RETURN to continue\r\n"
+                                % error)
 
     def process_mfa_push(self, endpoint, url, statetoken):
-        print("Waiting for result of push notification ...")
+        getpass.getpass(("Waiting for result of push notification ..."
+                         "press RETURN to continue"))
         while True:
             totp_response = self._requests_session.post(
                 url,
@@ -311,7 +314,9 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
             if totp_response.status_code == 200:
                 return self.get_assertion_from_response(endpoint, totp_parsed)
             elif totp_response.status_code >= 400:
-                print(totp_parsed["errorCauses"][0]["errorSummary"])
+                error = totp_parsed["errorCauses"][0]["errorSummary"]
+                getpass.getpass("%s\r\nPress RETURN to continue\r\n"
+                                % error)
 
     def verify_sms_factor(self, url, statetoken, passcode):
         body = {'stateToken': statetoken}
@@ -326,7 +331,8 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
 
     def process_mfa_sms(self, endpoint, url, statetoken):
         # Need to trigger the initial code to be sent ...
-        print("Requesting code to be sent to your phone ...")
+        getpass.getpass(("Requesting code to be sent to your phone ..."
+                         " press RETURN to continue"))
         self.verify_sms_factor(url, statetoken, "")
         while True:
             response = self.get_response(self._MSG_SMS_CODE)
@@ -341,32 +347,39 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
                     return self.get_assertion_from_response(endpoint,
                                                             sms_parsed)
                 elif sms_response.status_code >= 400:
-                    print(sms_parsed["errorCauses"][0]["errorSummary"])
+                    error = sms_parsed["errorCauses"][0]["errorSummary"]
+                    getpass.getpass("%s\r\nPress RETURN to continue\r\n"
+                                    % error)
 
     def display_mfa_choices(self, parsed):
         index = 1
+        prompt = ""
         for f in parsed["_embedded"]["factors"]:
             if f["factorType"] == "token":
-                print("%s: %s token" % (index, f["provider"]))
+                prompt += "%s: %s token\r\n" % (index, f["provider"])
             elif f["factorType"] == "token:software:totp":
-                print("%s: %s authenticator app" % (index, f["provider"]))
+                prompt += ("%s: %s authenticator app\r\n"
+                           % (index, f["provider"]))
             elif f["factorType"] == "sms":
-                print("%s: SMS text message" % index)
+                prompt += "%s: SMS text message\r\n" % index
             elif f["factorType"] == "push":
-                print("%s: Push notification" % index)
+                prompt += "%s: Push notification\r\n" % index
             elif f["factorType"] == "question":
-                print("%s: Security question" % index)
+                prompt += "%s: Security question\r\n" % index
             else:
-                print("%s: %s %s" % (index, f["provider"], f["factorType"]))
+                prompt += "%s: %s %s\r\n" % (index,
+                                             f["provider"],
+                                             f["factorType"])
             index += 1
-        return index
+        return index, prompt
 
     def get_mfa_choice(self, parsed):
         while True:
-            print("Please choose from the following authentication choices:")
-            count = self.display_mfa_choices(parsed)
-            print("Enter the number corresponding to your choice "
-                  "or press RETURN")
+            count, prompt = self.display_mfa_choices(parsed)
+            prompt = ("Please choose from the following authentication"
+                      "choices:\r\n") + prompt
+            prompt += ("Enter the number corresponding to your choice "
+                       "or press RETURN\r\n")
             response = self.get_response("to cancel authentication: ")
             choice = 0
             try:

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -378,7 +378,7 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
         while True:
             count, prompt = self.display_mfa_choices(parsed)
             prompt = ("Please choose from the following authentication"
-                      "choices:\r\n") + prompt
+                      " choices:\r\n") + prompt
             prompt += ("Enter the number corresponding to your choice "
                        "or press RETURN to cancel authentication: ")
             response = self._password_prompter(prompt)

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -281,12 +281,12 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
                 return self.get_assertion_from_response(endpoint, totp_parsed)
             elif totp_response.status_code >= 400:
                 error = totp_parsed["errorCauses"][0]["errorSummary"]
-                getpass.getpass("%s\r\nPress RETURN to continue\r\n"
-                                % error)
+                _password_prompter("%s\r\nPress RETURN to continue\r\n"
+                                   % error)
 
     def process_mfa_push(self, endpoint, url, statetoken):
-        getpass.getpass(("Waiting for result of push notification ..."
-                         "press RETURN to continue"))
+        _password_prompter(("Waiting for result of push notification ..."
+                            "press RETURN to continue"))
         while True:
             totp_response = self._requests_session.post(
                 url,
@@ -315,8 +315,8 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
                 return self.get_assertion_from_response(endpoint, totp_parsed)
             elif totp_response.status_code >= 400:
                 error = totp_parsed["errorCauses"][0]["errorSummary"]
-                getpass.getpass("%s\r\nPress RETURN to continue\r\n"
-                                % error)
+                _password_prompter("%s\r\nPress RETURN to continue\r\n"
+                                   % error)
 
     def verify_sms_factor(self, url, statetoken, passcode):
         body = {'stateToken': statetoken}
@@ -331,8 +331,8 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
 
     def process_mfa_sms(self, endpoint, url, statetoken):
         # Need to trigger the initial code to be sent ...
-        getpass.getpass(("Requesting code to be sent to your phone ..."
-                         " press RETURN to continue"))
+        _password_prompter(("Requesting code to be sent to your phone ..."
+                            " press RETURN to continue"))
         self.verify_sms_factor(url, statetoken, "")
         while True:
             response = self.get_response(self._MSG_SMS_CODE)
@@ -348,8 +348,8 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
                                                             sms_parsed)
                 elif sms_response.status_code >= 400:
                     error = sms_parsed["errorCauses"][0]["errorSummary"]
-                    getpass.getpass("%s\r\nPress RETURN to continue\r\n"
-                                    % error)
+                    _password_prompter("%s\r\nPress RETURN to continue\r\n"
+                                       % error)
 
     def display_mfa_choices(self, parsed):
         index = 1
@@ -380,7 +380,7 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
                       "choices:\r\n") + prompt
             prompt += ("Enter the number corresponding to your choice "
                        "or press RETURN to cancel authentication: ")
-            response = self.get_response(prompt)
+            response = self._password_prompter(prompt)
             choice = 0
             try:
                 choice = int(response)

--- a/awsprocesscreds/saml.py
+++ b/awsprocesscreds/saml.py
@@ -284,10 +284,10 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
             if totp_response.status_code == 200:
                 return self.get_assertion_from_response(endpoint, totp_parsed)
             elif totp_response.status_code >= 400:
-                print totp_parsed["errorCauses"][0]["errorSummary"]
+                print(totp_parsed["errorCauses"][0]["errorSummary"])
 
     def process_mfa_push(self, endpoint, url, statetoken):
-        print "Waiting for result of push notification ..."
+        print("Waiting for result of push notification ...")
         while True:
             totp_response = self._requests_session.post(
                 url,
@@ -315,7 +315,7 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
             if totp_response.status_code == 200:
                 return self.get_assertion_from_response(endpoint, totp_parsed)
             elif totp_response.status_code >= 400:
-                print totp_parsed["errorCauses"][0]["errorSummary"]
+                print(totp_parsed["errorCauses"][0]["errorSummary"])
 
     def verify_sms_factor(self, url, statetoken, passcode):
         body = {'stateToken': statetoken}
@@ -330,7 +330,7 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
 
     def process_mfa_sms(self, endpoint, url, statetoken):
         # Need to trigger the initial code to be sent ...
-        print "Requesting code to be sent to your phone ..."
+        print("Requesting code to be sent to your phone ...")
         self.verify_sms_factor(url, statetoken, "")
         while True:
             response = self.get_response(self._MSG_SMS_CODE)
@@ -345,32 +345,32 @@ class OktaAuthenticator(GenericFormsBasedAuthenticator):
                     return self.get_assertion_from_response(endpoint,
                                                             sms_parsed)
                 elif sms_response.status_code >= 400:
-                    print sms_parsed["errorCauses"][0]["errorSummary"]
+                    print(sms_parsed["errorCauses"][0]["errorSummary"])
 
     def display_mfa_choices(self, parsed):
         index = 1
         for f in parsed["_embedded"]["factors"]:
             if f["factorType"] == "token":
-                print "%s: %s token" % (index, f["provider"])
+                print("%s: %s token" % (index, f["provider"]))
             elif f["factorType"] == "token:software:totp":
-                print "%s: %s authenticator app" % (index, f["provider"])
+                print("%s: %s authenticator app" % (index, f["provider"]))
             elif f["factorType"] == "sms":
-                print "%s: SMS text message" % index
+                print("%s: SMS text message" % index)
             elif f["factorType"] == "push":
-                print "%s: Push notification" % index
+                print("%s: Push notification" % index)
             elif f["factorType"] == "question":
-                print "%s: Security question" % index
+                print("%s: Security question" % index)
             else:
-                print "%s: %s %s" % (index, f["provider"], f["factorType"])
+                print("%s: %s %s" % (index, f["provider"], f["factorType"]))
             index += 1
         return index
 
     def get_mfa_choice(self, parsed):
         while True:
-            print "Please choose from the following authentication choices:"
+            print("Please choose from the following authentication choices:")
             count = self.display_mfa_choices(parsed)
-            print ("Enter the number corresponding to your choice "
-                   "or press RETURN")
+            print("Enter the number corresponding to your choice "
+                  "or press RETURN")
             response = self.get_response("to cancel authentication: ")
             choice = 0
             try:

--- a/tests/unit/test_saml.py
+++ b/tests/unit/test_saml.py
@@ -349,6 +349,10 @@ class TestSAMLGenericFormsBasedAuthenticator(object):
         with pytest.raises(SAMLError):
             generic_auth.retrieve_saml_assertion(generic_config)
 
+    def test_append_query_string(self, generic_auth):
+        appended = generic_auth._append_query_string('https://www.google.com/search?q=42',
+                                                     {'hl': ['en']})
+        assert appended == 'https://www.google.com/search?q=42&hl=en'
 
 class TestOktaAuthenticator(object):
     def test_is_suitable(self, okta_auth, okta_config):


### PR DESCRIPTION
RelayState is particularly useful for federated okta setups where the
end user has to log into okta instance 1, log into okta instance 2
through okta instance 1, then log into aws through okta instance 2
https://saml-doc.okta.com/SAML_Docs/Configure-SAML-2.0-for-Org2Org.html